### PR TITLE
✨ Add Feature oauth2 pkce flow

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -9,6 +9,7 @@ export 'package:github_flutter/src/common/util/device_flow.dart';
 export 'package:github_flutter/src/common/util/errors.dart';
 export 'package:github_flutter/src/common/util/json.dart';
 export 'package:github_flutter/src/common/util/oauth2.dart';
+export 'package:github_flutter/src/common/util/oauth2_pkce.dart';
 export 'package:github_flutter/src/common/util/pagination.dart';
 export 'package:github_flutter/src/common/util/service.dart';
 export 'package:github_flutter/src/common/util/utils.dart';

--- a/lib/src/common/util/oauth2_pkce.dart
+++ b/lib/src/common/util/oauth2_pkce.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:github_flutter/src/common.dart';
+import 'package:http/http.dart' as http;
+
+class OAuth2PKCE {
+  /// OAuth2 Client ID
+  final String clientId;
+
+  /// Requested Scopes
+  final List<String> scopes;
+
+  /// Redirect URI
+  final String? redirectUri;
+
+  /// State
+  final String? state;
+
+  /// OAuth2 Base URL
+  final String baseUrl;
+
+  /// Confidential Intermediary Server URL
+  final String confidentialIntermediaryServer;
+
+  GitHub? github;
+
+  /// Constructor to initialize [OAuth2PKCE] with required parameters.
+  OAuth2PKCE(
+    this.clientId,
+    this.confidentialIntermediaryServer, {
+    String? redirectUri,
+    this.scopes = const [],
+    this.state,
+    this.github,
+    this.baseUrl = 'https://github.com/login/oauth',
+  }) : redirectUri =
+           redirectUri == null ? null : _checkRedirectUri(redirectUri);
+
+  static String _checkRedirectUri(String uri) {
+    return uri.contains('?') ? uri.substring(0, uri.indexOf('?')) : uri;
+  }
+
+  /// Generates an Authorization URL
+  ///
+  /// This should be displayed to the user.
+  String createAuthorizeUrl() {
+    return '$baseUrl/authorize${buildQueryString({'client_id': clientId, 'scope': scopes.join(','), 'redirect_uri': redirectUri, 'state': state})}';
+  }
+
+  Future<ExchangeResponse> exchange(
+    String code,
+    String codeVerifier, [
+    String? origin,
+  ]) async {
+    final headers = <String, String>{
+      'Accept': 'application/json',
+      'content-type': 'application/json',
+    };
+    if (origin != null) {
+      headers['Origin'] = origin;
+    }
+
+    final body = GitHubJson.encode(<String, dynamic>{
+      'client_id': clientId,
+      'code_verifier': codeVerifier,
+      'code': code,
+      'redirect_uri': redirectUri,
+    });
+
+    return (github == null ? http.Client() : github!.client)
+        .post(
+          Uri.parse(confidentialIntermediaryServer),
+          body: body,
+          headers: headers,
+        )
+        .then((response) {
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          if (json['error'] != null) {
+            throw Exception(json['error']);
+          }
+          return ExchangeResponse(
+            json['access_token'],
+            json['token_type'],
+            (json['scope'] as String).split(','),
+          );
+        });
+  }
+}
+
+/// Represents a response for exchanging a code for a token.
+class ExchangeResponse {
+  final String? token;
+  final List<String> scopes;
+  final String? tokenType;
+
+  ExchangeResponse(this.token, this.tokenType, this.scopes);
+}

--- a/lib/src/common/util/oauth2_pkce.dart
+++ b/lib/src/common/util/oauth2_pkce.dart
@@ -44,8 +44,8 @@ class OAuth2PKCE {
   /// Generates an Authorization URL
   ///
   /// This should be displayed to the user.
-  String createAuthorizeUrl() {
-    return '$baseUrl/authorize${buildQueryString({'client_id': clientId, 'scope': scopes.join(','), 'redirect_uri': redirectUri, 'state': state})}';
+  String createAuthorizeUrl(String codeChallenge) {
+    return '$baseUrl/authorize${buildQueryString({'client_id': clientId, 'scope': scopes.join(','), 'redirect_uri': redirectUri, 'state': state, 'code_challenge': codeChallenge, 'code_challenge_method': 'S256'})}';
   }
 
   Future<ExchangeResponse> exchange(

--- a/lib/src/common/util/oauth2_pkce.dart
+++ b/lib/src/common/util/oauth2_pkce.dart
@@ -87,12 +87,3 @@ class OAuth2PKCE {
         });
   }
 }
-
-/// Represents a response for exchanging a code for a token.
-class ExchangeResponse {
-  final String? token;
-  final List<String> scopes;
-  final String? tokenType;
-
-  ExchangeResponse(this.token, this.tokenType, this.scopes);
-}


### PR DESCRIPTION
This pull request introduces a new `OAuth2PKCE` class to support OAuth 2.0 with Proof Key for Code Exchange (PKCE) in the `github_flutter` package. The changes include adding a new utility file and updating exports to make the new class accessible.

### New Feature: OAuth 2.0 PKCE Support
* **Added `OAuth2PKCE` class**: Implements OAuth 2.0 PKCE flow with methods to generate authorization URLs and exchange authorization codes for access tokens. This includes handling client ID, scopes, redirect URI, and state, as well as making HTTP requests to the OAuth server. (`lib/src/common/util/oauth2_pkce.dart`)

### Codebase Update:
* **Updated exports**: Added `oauth2_pkce.dart` to the exports in `lib/src/common.dart` to make the new `OAuth2PKCE` class accessible throughout the package. (`lib/src/common.dart`)