### PR TITLE
✨ Add graphql support and add first graphql endpoint

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -6,6 +6,8 @@ import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart' as http_parser;
 import 'package:meta/meta.dart';
 
+import 'graphql_service.dart';
+
 ///  The Main GitHub Client
 ///
 ///  ## Example
@@ -63,6 +65,7 @@ class GitHub {
   UrlShortenerService? _urlShortener;
   UsersService? _users;
   ChecksService? _checks;
+  GraphQLService? _graphql;
 
   /// The maximum number of requests that the consumer is permitted to make per
   /// hour.
@@ -142,6 +145,9 @@ class GitHub {
   ///
   /// See https://developer.github.com/v3/checks/
   ChecksService get checks => _checks ??= ChecksService(this);
+
+  /// Service for GraphQL related methods of the GitHub API.
+  GraphQLService get graphql => _graphql ??= GraphQLService(this);
 
   /// Handles Get Requests that respond with JSON
   /// [path] can either be a path like '/repos' or a full url.

--- a/lib/src/common/graphql_service.dart
+++ b/lib/src/common/graphql_service.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:graphql/client.dart';
+
+import 'github.dart';
+
+/// Service for handling GraphQL requests.
+class GraphQLService {
+  final GitHub github;
+  late final GraphQLClient _client;
+
+  GraphQLService(this.github) {
+    final httpLink = HttpLink('https://api.github.com/graphql');
+
+    final authLink = AuthLink(
+      getToken: () async => 'Bearer ${github.auth.token}',
+    );
+
+    final link = authLink.concat(httpLink);
+
+    _client = GraphQLClient(cache: GraphQLCache(), link: link);
+  }
+
+  /// Performs a GraphQL query.
+  Future<QueryResult> query(
+    String query, {
+    Map<String, dynamic>? variables,
+  }) async {
+    final options = QueryOptions(
+      document: gql(query),
+      variables: variables ?? const <String, dynamic>{},
+    );
+    return _client.query(options);
+  }
+
+  /// Performs a GraphQL mutation.
+  Future<QueryResult> mutate(
+    String mutation, {
+    Map<String, dynamic>? variables,
+  }) async {
+    final options = MutationOptions(
+      document: gql(mutation),
+      variables: variables ?? const <String, dynamic>{},
+    );
+    return _client.mutate(options);
+  }
+}

--- a/lib/src/services/issues_service.dart
+++ b/lib/src/services/issues_service.dart
@@ -574,7 +574,7 @@ class IssuesService extends Service {
   ///
   /// API docs: https://docs.github.com/en/graphql/reference/mutations#deleteissue
   Future<void> deleteIssue(String issueId) async {
-    const String mutation = r'''
+    const mutation = r'''
       mutation DeleteIssue($issueId: ID!) {
         deleteIssue(input: {issueId: $issueId}) {
           clientMutationId

--- a/lib/src/services/issues_service.dart
+++ b/lib/src/services/issues_service.dart
@@ -566,4 +566,29 @@ class IssuesService extends Service {
       statusCode: 204,
     );
   }
+
+  /// Deletes an issue.
+  ///
+  /// This uses the GraphQL API, since issue deletion is not available in the REST API.
+  /// [issueId] is the GraphQL node ID of the issue, not the issue number.
+  ///
+  /// API docs: https://docs.github.com/en/graphql/reference/mutations#deleteissue
+  Future<void> deleteIssue(String issueId) async {
+    const String mutation = r'''
+      mutation DeleteIssue($issueId: ID!) {
+        deleteIssue(input: {issueId: $issueId}) {
+          clientMutationId
+        }
+      }
+    ''';
+
+    final result = await github.graphql.mutate(
+      mutation,
+      variables: {'issueId': issueId},
+    );
+
+    if (result.hasException) {
+      throw result.exception!;
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  graphql: ^5.2.1
   http: ^1.3.0
   http_parser:
   json_annotation: ^4.9.0

--- a/test/unit/issues_test.dart
+++ b/test/unit/issues_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
-import 'package:github_flutter/src/models/issues.dart';
+import 'package:github_flutter/src/common.dart';
+import 'package:github_flutter/src/common/graphql_service.dart';
+import 'package:graphql/client.dart';
 import 'package:test/test.dart';
 
 const String testIssueCommentJson = '''
@@ -50,6 +52,41 @@ const String testIssueCommentJson = '''
   }
 ''';
 
+// A mock implementation of GitHub that uses noSuchMethod to avoid implementing
+// all methods of the GitHub class.
+class MockGitHub implements GitHub {
+  @override
+  late final GraphQLService graphql;
+
+  MockGitHub(this.graphql);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return super.noSuchMethod(invocation);
+  }
+}
+
+// A manual mock for GraphQLService to avoid mockito issues.
+class MockGraphQLService implements GraphQLService {
+  // Callback to be set by the test.
+  late Future<QueryResult> Function(String, Map<String, dynamic>?) onMutate;
+
+  @override
+  Future<QueryResult> mutate(
+    String mutation, {
+    Map<String, dynamic>? variables,
+  }) {
+    return onMutate(mutation, variables);
+  }
+
+  // Unimplemented members
+  @override
+  GitHub get github => throw UnimplementedError();
+  @override
+  Future<QueryResult> query(String query, {Map<String, dynamic>? variables}) =>
+      throw UnimplementedError();
+}
+
 void main() {
   group('Issue Comments', () {
     test('IssueComment from Json', () {
@@ -59,6 +96,67 @@ void main() {
       expect(1352355796, issueComment.id);
       expect('MEMBER', issueComment.authorAssociation);
       expect('CaseyHillers', issueComment.user!.login);
+    });
+  });
+
+  group('IssuesService', () {
+    late IssuesService issuesService;
+    late MockGitHub mockGitHub;
+    late MockGraphQLService mockGraphQLService;
+
+    setUp(() {
+      mockGraphQLService = MockGraphQLService();
+      mockGitHub = MockGitHub(mockGraphQLService);
+      issuesService = IssuesService(mockGitHub);
+    });
+
+    test('deleteIssue success', () async {
+      // Arrange
+      String? capturedMutation;
+      Map<String, dynamic>? capturedVariables;
+
+      mockGraphQLService.onMutate = (mutation, variables) {
+        capturedMutation = mutation;
+        capturedVariables = variables;
+        return Future.value(
+          QueryResult(
+            options: QueryOptions(document: gql('')),
+            source: QueryResultSource.network,
+            data: const {
+              'deleteIssue': {'clientMutationId': '1234'},
+            },
+          ),
+        );
+      };
+
+      // Act
+      await issuesService.deleteIssue('issue-id-123');
+
+      // Assert
+      expect(capturedMutation, contains('mutation DeleteIssue'));
+      expect(capturedVariables, {'issueId': 'issue-id-123'});
+    });
+
+    test('deleteIssue failure', () async {
+      // Arrange
+      final exception = OperationException(
+        graphqlErrors: [const GraphQLError(message: 'Failed to delete')],
+      );
+      mockGraphQLService.onMutate = (mutation, variables) {
+        return Future.value(
+          QueryResult(
+            options: QueryOptions(document: gql('')),
+            source: QueryResultSource.network,
+            exception: exception,
+          ),
+        );
+      };
+
+      // Act & Assert
+      expect(
+        () => issuesService.deleteIssue('issue-id-123'),
+        throwsA(isA<OperationException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
This pull request introduces GraphQL support to the GitHub client library and adds the ability to delete issues using the GitHub GraphQL API. The main changes include adding a new `GraphQLService`, updating the `GitHub` client to expose GraphQL functionality, extending the `IssuesService` with a `deleteIssue` method, and adding unit tests for issue deletion.

**GraphQL Integration:**

* Added a new `GraphQLService` class (`lib/src/common/graphql_service.dart`) to handle GraphQL queries and mutations, using the `graphql` package.
* Updated the `GitHub` client (`lib/src/common/github.dart`) to include a `graphql` getter, providing access to the new GraphQL service. [[1]](diffhunk://#diff-923d99f60005f5582c726430d72c62e01e5cf477efcd0771f9ad7a64ad08f197R9-R10) [[2]](diffhunk://#diff-923d99f60005f5582c726430d72c62e01e5cf477efcd0771f9ad7a64ad08f197R68) [[3]](diffhunk://#diff-923d99f60005f5582c726430d72c62e01e5cf477efcd0771f9ad7a64ad08f197R149-R151)
* Added the `graphql` package as a dependency in `pubspec.yaml`.

**Issue Deletion Feature:**

* Implemented a new `deleteIssue` method in `IssuesService` (`lib/src/services/issues_service.dart`) that deletes issues via the GraphQL API, since this functionality is not available in the REST API.

**Testing Enhancements:**

* Added manual mocks for `GitHub` and `GraphQLService` in the unit tests, and introduced tests for the new `deleteIssue` method, covering both success and failure scenarios (`test/unit/issues_test.dart`). [[1]](diffhunk://#diff-fefb5e4ea8f5a5deb677f3796cfc6602285f13e44ae2fabbda39457b545fe123L3-R5) [[2]](diffhunk://#diff-fefb5e4ea8f5a5deb677f3796cfc6602285f13e44ae2fabbda39457b545fe123R55-R89) [[3]](diffhunk://#diff-fefb5e4ea8f5a5deb677f3796cfc6602285f13e44ae2fabbda39457b545fe123R101-R161)