### PR TITLE
:bug: Fix authentication token retrieval in GraphQL service

### DIFF
--- a/lib/src/common/graphql_service.dart
+++ b/lib/src/common/graphql_service.dart
@@ -13,7 +13,7 @@ class GraphQLService {
     final httpLink = HttpLink('https://api.github.com/graphql');
 
     final authLink = AuthLink(
-      getToken: () async => 'Bearer ${github.auth.token}',
+      getToken: () async => 'Bearer ${github.auth.bearerToken}',
     );
 
     final link = authLink.concat(httpLink);


### PR DESCRIPTION
**Description:**
This PR fixes an issue in the GraphQLService class where authentication was not correctly applied, causing GitHub GraphQL requests to fail. With this fix, the service now properly includes the authentication token in requests, ensuring that all GraphQL queries and mutations are executed successfully.

**Changes:**

Corrected the authentication handling in GraphQLService.
Verified that GitHub GraphQL queries now return expected results.

**Impact:**

GitHub GraphQL requests are now correctly authenticated.
Downstream features depending on GraphQL queries should function as expected.